### PR TITLE
always use the latest version

### DIFF
--- a/get_crave.ps1
+++ b/get_crave.ps1
@@ -2,17 +2,22 @@
 
 $OS="Windows"
 
-$Env:CRAVE_URL_BASE = "https://github.com/accupara/crave/releases/download/"
-$Env:CRAVE_VERSION = "0.2-6956"
+$Env:CRAVE_URL_BASE = "https://github.com/accupara/crave/releases/latest/download/"
 $Env:CRAVE_POSTFIX = ".zip"
+
 if ($IsWindows -or $ENV:OS) {
-    Write-Host "Downloading $Env:CRAVE_VERSION for Windows"
+    Write-Host "Downloading latest version of Crave for Windows"
 } else {
     Write-Host "Only Windows host is supported for auto installation with this script."
     exit 1
 }
 
-$Env:CRAVE_URL = $Env:CRAVE_URL_BASE + "/" + $Env:CRAVE_VERSION + "/" + "crave-windows-" + $Env:CRAVE_VERSION + "-" + $OS + $Env:CRAVE_POSTFIX
+$Env:CRAVE_URL = (Invoke-WebRequest -Uri $Env:CRAVE_URL_BASE -UseBasicParsing | ConvertFrom-Json).assets | Where-Object { $_.name -like "*windows*" -and $_.name -like "*.zip" } | Select-Object -ExpandProperty browser_download_url
+
+if (-not $Env:CRAVE_URL) {
+    Write-Host "Unable to fetch the download link. Please try again later."
+    exit 1
+}
 
 Invoke-WebRequest $Env:CRAVE_URL -OutFile 'crave-bin.zip'
 Write-Host "Download complete.. Expanding archive."

--- a/get_crave.sh
+++ b/get_crave.sh
@@ -2,57 +2,54 @@
 # Copyright (c) 2020-2024 Crave crave.io Inc. All rights reserved
 
 os='linux'
-crave_url_base='https://github.com/accupara/crave/releases/download/'
-crave_version='0.2-6956'
-crave_arch='amd64'
+crave_url_base='https://github.com/accupara/crave/releases/latest/download/'
+crave_arch=$(uname -m)
 crave_postfix='.bin'
 crave_default_location='/usr/local/bin'
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    # Linux
-    os='linux'
-    crave_arch=`uname -m`
-    if [[ "$crave_arch" == "arm64" ]]; then
-        crave_arch="aarch64"
-    fi
-    if [[ "$crave_arch" == "x86_64" ]]; then
-        crave_arch="amd64"
-    fi
-elif [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ "$OSTYPE" == "darwin"* ]]; then
     # Mac OSX
     os='darwin'
-else
-    # Unknown.
-    os='unknown'
+    crave_arch="amd64"  # For macOS, using amd64 architecture
+elif [[ "$crave_arch" == "arm64" ]]; then
+    # Arm architecture
+    crave_arch="aarch64"
+elif [[ "$crave_arch" == "x86_64" ]]; then
+    # AMD64 architecture
+    crave_arch="amd64"
 fi
 
-if [[ "os" == 'unknown' ]]; then
-    echo Only OSX and Linux are supported for auto installation at this time
+if [[ "$os" == 'unknown' ]]; then
+    echo "Only OSX and Linux are supported for auto installation at this time"
     exit 1
 fi
 
-crave_url="$crave_url_base/$crave_version/crave-$crave_version-$os-$crave_arch$crave_postfix"
+crave_url=$(wget -q -O - https://api.github.com/repos/accupara/crave/releases/latest | jq -r '.assets[] | select(.name | contains("'"$os-$crave_arch$crave_postfix"'")) | .browser_download_url')
 
-curl -L $crave_url --output crave
+if [[ "$crave_url" == "null" ]]; then
+    echo "Unable to fetch the download link. Please try again later."
+    exit 1
+fi
+
+wget "$crave_url" -O crave
 chmod +x crave
 
-
-if [ -p /dev/stdin ] ; then
+if [ -p /dev/stdin ]; then
     install_crave=false
 else
     echo -n "Install to system path (default: /usr/local/bin) [y]/n ? "
     read ans
     case $ans in
         Y|y|1|"" ) install_crave=true;;
-        N|n|2 )  echo "Skpping crave install"; install_crave=false;;
-        *     )  echo "Unknow input"; exit ;;
+        N|n|2 )  echo "Skipping crave install"; install_crave=false;;
+        *     )  echo "Unknown input"; exit ;;
     esac
 fi
 
 if [[ $install_crave == true ]]; then
     echo -n "Location to install crave [/usr/local/bin]: "
     read crave_location
-    if [[ "$crave_locatin" == "" ]]; then
+    if [[ "$crave_location" == "" ]]; then
        crave_location="$crave_default_location"
     fi
     echo "Installing crave to location $crave_location (will require root)"


### PR DESCRIPTION
Instead of adding the latest version to the line, it will automatically download and install the latest version every time.

I was able to test it on arm64 and amd64 Linux platforms only. I would recommend testing before merging.