### PR TITLE
get_crave.sh: Add new OSTYPE string to linux

### DIFF
--- a/get_crave.sh
+++ b/get_crave.sh
@@ -8,7 +8,7 @@ crave_arch='amd64'
 crave_postfix='.bin'
 crave_default_location='/usr/local/bin'
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "linux"* ]]; then
     # Linux
     os='linux'
     crave_arch=`uname -m`


### PR DESCRIPTION
My recent OpenSUSE tumbleweed install running Budgie seemed to be recognized as just `linux` which crave threw into the unknown category

With this little fix, my laptop is now able to fetch crave